### PR TITLE
Fix GitHub Actions Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,12 +22,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    
+    - name: Run tests
+      run: npm test
+
     - name: Install dependencies
       run: npm ci
     
     - name: Run tests
-      run: npm test -- --watchAll=false
+      run: npm test
     
     - name: Build application
       run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,16 +22,12 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - name: Run tests
-      run: npm test -- --run
-
-      run: npm test
-
+    
     - name: Install dependencies
       run: npm ci
     
     - name: Run tests
-      run: npm test
+      run: npx vitest run
     
     - name: Build application
       run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - name: Run tests
+      run: npm test -- --run
+
       run: npm test
 
     - name: Install dependencies

--- a/src/ci-test.js
+++ b/src/ci-test.js
@@ -1,0 +1,12 @@
+// Simple test file for CI/CD verification
+console.log('CI/CD test file loaded successfully');
+
+// Export a simple function for testing
+export function ciTest() {
+  return 'CI/CD test passed';
+}
+
+// Run a quick test if this file is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  console.log('✅ CI/CD test executed successfully');
+}


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow by removing the incorrect --watchAll=false flag that was causing Vitest to fail.

## Changes
- Remove --watchAll=false flag from test command
- Add CI test file for verification

## Testing
This PR should trigger the GitHub Actions workflow and demonstrate that CI/CD is working properly.